### PR TITLE
Neighbor cell measurement RSRQ ranges from -34.5 to 3.5 dB

### DIFF
--- a/api-verification/locate.spec.ts
+++ b/api-verification/locate.spec.ts
@@ -226,6 +226,48 @@ describe('multi-cell location', () => {
 			await post({ resource: 'location/cell', payload: cellTowers }),
 		).toMatchLocation(expectedLocation)
 	})
+
+	it('should resolve this multi-cell result', async () => {
+		expect(async () =>
+			post({
+				resource: 'location/cell',
+				payload: {
+					lte: [
+						{
+							mcc: 242,
+							mnc: 2,
+							eci: 34237195,
+							tac: 2305,
+							earfcn: 1650,
+							adv: 65535,
+							rsrp: -74,
+							rsrq: -7,
+							nmr: [
+								{
+									pci: 64,
+									rsrp: -85,
+									rsrq: -18,
+									earfcn: 1650,
+								},
+								{
+									pci: 100,
+									rsrp: -94,
+									rsrq: -26,
+									earfcn: 1650,
+								},
+								{
+									pci: 191,
+									rsrp: -95,
+									rsrq: -26,
+									earfcn: 1650,
+								},
+							],
+						},
+					],
+				},
+			}),
+		).not.toThrow()
+	})
 })
 
 describe('single-cell location', () => {


### PR DESCRIPTION
The modem reports rsrq of -26, however the [nRF Cloud Location Services rejects all rsrq values smaller than -19.5](https://api.nrfcloud.com/v1#operation/GetPositionFromCellTowers).

[NCELLMEAS command has a index range of -30 to 46](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fref_at_commands%2FREF%2Fat_commands%2Fmob_termination_ctrl_status%2Fncellmeas_set.html) which results in a dB range of -34.5 to 3.5dB when adjusted with the formula `v * 0.5 - 19.5`, [as done in the firmware](https://github.com/nrfconnect/sdk-nrf/blob/9ea53264e03fa4dd075446f8e485282c39b2a461/applications/asset_tracker_v2/src/modules/modem_module.c#L270-L273).

This problem was seen first in our requests on 2021-09-24T15:10:53.493+02:00